### PR TITLE
修复前后端时间戳不一致导致的逻辑问题

### DIFF
--- a/Unity/Assets/Hotfix/Module/Message/PingComponentSystem.cs
+++ b/Unity/Assets/Hotfix/Module/Message/PingComponentSystem.cs
@@ -57,20 +57,24 @@ namespace ET
                     
                     M2C_Ping responseFromMap = await session.Call(self.C2M_Ping) as M2C_Ping;
                     
-                    self.C2MPingValue =
-                        (uint) Mathf.Clamp((responseFromMap.TimePoint - clientNow_C2MSend) * 2, 0.0f,
-                            999.0f);
+                    float oldPing = self.C2MPingValue;
+                    self.C2MPingValue = TimeHelper.ClientNow() - clientNow_C2MSend;
 
-                    //TODO 这里是只有C2M的ping发生变化才发送通知
-                    Game.EventSystem.Publish(new EventType.PingChange()
-                        {
-                            C2GPing = self.C2GPingValue,
-                            C2MPing = self.C2MPingValue,
-                            ServerTimeSnap = responseFromMap.TimePoint,
-                            MessageFrame = responseFromMap.ServerFrame,
-                            ZoneScene = self.DomainScene()
-                        })
-                        .Coroutine();
+                    if (oldPing != self.C2MPingValue)
+                    {
+                        //TODO 这里是只有C2M的ping发生变化才发送通知
+                        Game.EventSystem.Publish(new EventType.PingChange()
+                            {
+                                C2GPing = self.C2GPingValue,
+                                C2MPing = self.C2MPingValue,
+                                ServerTimeSnap = responseFromMap.TimePoint,
+                                MessageFrame = responseFromMap.ServerFrame,
+                                ZoneScene = self.DomainScene()
+                            })
+                            .Coroutine();
+                    }
+                    
+                    Game.TimeInfo.ServerMinusClientTime = responseFromGate.Time + (clientNow_C2MSend - clientNow_C2GSend) / 2 - clientNow_C2MSend;
                 }
                 catch (RpcException e)
                 {

--- a/Unity/Assets/Hotfix/Module/Message/PingComponentSystem.cs
+++ b/Unity/Assets/Hotfix/Module/Message/PingComponentSystem.cs
@@ -62,7 +62,6 @@ namespace ET
 
                     if (oldPing != self.C2MPingValue)
                     {
-                        //TODO 这里是只有C2M的ping发生变化才发送通知
                         Game.EventSystem.Publish(new EventType.PingChange()
                             {
                                 C2GPing = self.C2GPingValue,

--- a/Unity/Assets/Hotfix/NKGMOBA/Battle/LockStepStateFrameSync/LSF_ComponentUtilities.cs
+++ b/Unity/Assets/Hotfix/NKGMOBA/Battle/LockStepStateFrameSync/LSF_ComponentUtilities.cs
@@ -339,8 +339,9 @@ namespace ET
         public static void RefreshNetInfo(this LSF_Component self, long serverTimeSnap,
             uint messageFrame)
         {
-            self.ServerCurrentFrame = messageFrame + TimeAndFrameConverter.Frame_Long2Frame(
-                TimeHelper.ClientNow() - serverTimeSnap);
+            var serverPastTime = TimeHelper.ServerNow() - serverTimeSnap;
+            
+            self.ServerCurrentFrame = messageFrame + TimeAndFrameConverter.Frame_Long2Frame(serverPastTime);
             self.CurrentAheadOfFrame = (int) (self.CurrentFrame - self.ServerCurrentFrame);
 
             //Log.Info($"刷新服务端CurrentFrame成功：{self.ServerCurrentFrame} ---- {TimeHelper.ClientNow()}");


### PR DESCRIPTION
前后端时间戳不一致，算出来的帧会不一致，比如后端时间戳比前端时间戳慢10秒，假设固定帧率30帧，算出来的ServerFrame会比CurrentFrame多300多帧，修复了这个问题